### PR TITLE
Code Quality Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /node_modules/
 /vendor/
 .DS_Store
+.idea
 _build
 composer.lock
 package-lock.json

--- a/404.php
+++ b/404.php
@@ -25,7 +25,17 @@ get_header(); ?>
 					<div class="widget">
 						<h2 class="widgettitle"><?php _e( 'Most Used Categories', 'autonomie' ); ?></h2>
 						<ul>
-						<?php wp_list_categories( array( 'orderby' => 'count', 'order' => 'DESC', 'show_count' => 1, 'title_li' => '', 'number' => 10 ) ); ?>
+						<?php
+						wp_list_categories(
+							array(
+								'orderby' => 'count',
+								'order' => 'DESC',
+								'show_count' => 1,
+								'title_li' => '',
+								'number' => 10,
+							)
+						);
+						?>
 						</ul>
 					</div>
 
@@ -42,4 +52,5 @@ get_header(); ?>
 
 		</main><!-- #content -->
 
-<?php get_footer(); ?>
+<?php
+get_footer();

--- a/500.php
+++ b/500.php
@@ -23,4 +23,5 @@ get_header(); ?>
 
 		</main><!-- #content -->
 
-<?php get_footer(); ?>
+<?php
+get_footer();

--- a/archive.php
+++ b/archive.php
@@ -51,4 +51,5 @@ get_header(); ?>
 
 			</main><!-- #content -->
 
-<?php get_footer(); ?>
+<?php
+get_footer();

--- a/comments.php
+++ b/comments.php
@@ -31,9 +31,12 @@
 		<h2 id="comments-title">
 			<?php
 				printf(
-					/* translators: 1: number of comments, 2: post title */
+					/* translators:
+					%1$s: number of comments, mind to add this if your language uses singular for more than just n=1
+					%2$s: post title
+					*/
 					_n(
-						'One thought on &ldquo;%2$s&rdquo;',
+						'One thought on &ldquo;%2$s&rdquo;', // phpcs:ignore WordPress.WP.I18n.MissingSingularPlaceholder -- Translator instructions added.
 						'%1$s thoughts on &ldquo;%2$s&rdquo;',
 						get_comments_number(),
 						'autonomie'

--- a/comments.php
+++ b/comments.php
@@ -31,7 +31,13 @@
 		<h2 id="comments-title">
 			<?php
 				printf(
-					_n( 'One thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', get_comments_number(), 'autonomie' ),
+					/* translators: 1: number of comments, 2: post title */
+					_n(
+						'One thought on &ldquo;%2$s&rdquo;',
+						'%1$s thoughts on &ldquo;%2$s&rdquo;',
+						get_comments_number(),
+						'autonomie'
+					),
 					number_format_i18n( get_comments_number() ),
 					'<span>' . get_the_title() . '</span>'
 				);
@@ -54,7 +60,12 @@
 				 * define autonomie_comment() and that will be used instead.
 				 * See autonomie_comment() in autonomie/functions.php for more.
 				 */
-				wp_list_comments( array( 'callback' => 'autonomie_comment', 'format' => '' ) );
+				wp_list_comments(
+					array(
+						'callback' => 'autonomie_comment',
+						'format' => '',
+					)
+				);
 			?>
 		</ol>
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "pfefferle/wordpress-autonomie",
 	"description": "Pure Zen",
 	"require": {
-		"php": ">=5.6.0",
+		"php": ">=7.4.0",
 		"composer/installers": "~2.2"
 	},
 	"type": "wordpress-theme",
@@ -15,5 +15,10 @@
 	],
 	"extra": {
 		"installer-name": "autonomie"
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true
+		}
 	}
 }

--- a/footer.php
+++ b/footer.php
@@ -28,7 +28,14 @@
 
 		<div id="site-generator">
 			<?php do_action( 'autonomie_credits' ); ?>
-			<?php printf( __( 'This site is powered by %1$s and styled with the %2$s theme', 'autonomie' ), '<a href="https://wordpress.org/" rel="generator">WordPress</a>', '<a href="https://notiz.blog/projects/autonomie/">Autonomie</a>' ); ?>
+			<?php
+			printf(
+				// translators: %1$s: Link to WordPress, %2$s: Link to Autonomie theme.
+				__( 'This site is powered by %1$s and styled with the %2$s theme', 'autonomie' ),
+				'<a href="https://wordpress.org/" rel="generator">WordPress</a>',
+				'<a href="https://notiz.blog/projects/autonomie/">Autonomie</a>'
+			);
+			?>
 		</div>
 	</footer><!-- #colophon -->
 </div><!-- #page -->

--- a/functions.php
+++ b/functions.php
@@ -470,7 +470,7 @@ if ( ! function_exists( 'autonomie_comment' ) ) :
 		$GLOBALS['comment'] = $comment;
 		?>
 		<li <?php comment_class(); ?> id="li-comment-<?php comment_ID(); ?>">
-			<article id="comment-<?php comment_ID(); ?>" class="comment <?php $comment->comment_type; ?>" itemprop="comment" itemscope itemtype="https://schema.org/Comment">
+			<article id="comment-<?php comment_ID(); ?>" class="comment <?php echo $comment->comment_type; ?>" itemprop="comment" itemscope itemtype="https://schema.org/Comment">
 				<div class="edit-link"><?php edit_comment_link( __( 'Edit', 'autonomie' ), ' ' ); ?></div>
 				<footer class="comment-meta commentmetadata">
 					<address class="comment-author p-author author vcard hcard h-card" itemprop="creator" itemscope itemtype="https://schema.org/Person">
@@ -513,42 +513,42 @@ endif; // ends check for autonomie_comment()
 /**
  * All template functions
  */
-require( get_template_directory() . '/includes/template-functions.php' );
+require get_template_directory() . '/includes/template-functions.php';
 
 /**
  * Widget handling
  */
-require( get_template_directory() . '/includes/widgets.php' );
+require get_template_directory() . '/includes/widgets.php';
 
 /**
  * Adds the featured image functionality
  */
-require( get_template_directory() . '/includes/featured-image.php' );
+require get_template_directory() . '/includes/featured-image.php';
 
 /**
  * All customizer functions
  */
-require( get_template_directory() . '/includes/customizer.php' );
+require get_template_directory() . '/includes/customizer.php';
 
 /**
  * Adds some awesome websemantics like microformats(2) and microdata
  */
-require( get_template_directory() . '/includes/semantics.php' );
+require get_template_directory() . '/includes/semantics.php';
 
 /**
  * Add Webactions support
  */
-require( get_template_directory() . '/includes/webactions.php' );
+require get_template_directory() . '/includes/webactions.php';
 
 /**
  * Adds back compat handling for older WP versions
  */
-require( get_template_directory() . '/includes/compat.php' );
+require get_template_directory() . '/includes/compat.php';
 
 /**
  * Feed extensions
  */
-require( get_template_directory() . '/includes/feed.php' );
+require get_template_directory() . '/includes/feed.php';
 
 /**
  * Compatibility with other plugins, mostly IndieWeb related
@@ -559,15 +559,15 @@ if ( defined( 'SYNDICATION_LINKS_VERSION' ) ) {
 	 * Adds Indieweb Syndcation Links
 	 * if github.com/dshanske/syndication-links is activated
 	 */
-	require( get_template_directory() . '/integrations/syndication-links.php' );
+	require get_template_directory() . '/integrations/syndication-links.php';
 }
 
 if ( class_exists( 'Post_Kinds_Plugin' ) ) {
-	require( get_template_directory() . '/integrations/post-kinds.php' );
+	require get_template_directory() . '/integrations/post-kinds.php';
 }
 
 if ( class_exists( '\Activitypub\Activitypub' ) ) {
-	require( get_template_directory() . '/integrations/activitypub.php' );
+	require get_template_directory() . '/integrations/activitypub.php';
 }
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -470,7 +470,7 @@ if ( ! function_exists( 'autonomie_comment' ) ) :
 		$GLOBALS['comment'] = $comment;
 		?>
 		<li <?php comment_class(); ?> id="li-comment-<?php comment_ID(); ?>">
-			<article id="comment-<?php comment_ID(); ?>" class="comment <?php echo $comment->comment_type; ?>" itemprop="comment" itemscope itemtype="https://schema.org/Comment">
+			<article id="comment-<?php comment_ID(); ?>" class="comment <?php echo esc_attr( $comment->comment_type ); ?>" itemprop="comment" itemscope itemtype="https://schema.org/Comment">
 				<div class="edit-link"><?php edit_comment_link( __( 'Edit', 'autonomie' ), ' ' ); ?></div>
 				<footer class="comment-meta commentmetadata">
 					<address class="comment-author p-author author vcard hcard h-card" itemprop="creator" itemscope itemtype="https://schema.org/Person">

--- a/header.php
+++ b/header.php
@@ -12,8 +12,8 @@
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<link rel="profile" href="http://microformats.org/profile/specs" />
-	<link rel="profile" href="http://microformats.org/profile/hatom" />
+	<link rel="profile" href="https://microformats.org/profile/specs" />
+	<link rel="profile" href="https://microformats.org/profile/hatom" />
 
 	<?php wp_head(); ?>
 </head>

--- a/image.php
+++ b/image.php
@@ -10,7 +10,10 @@ get_header(); ?>
 
 			<main id="primary" <?php autonomie_main_class(); ?><?php autonomie_semantics( 'main' ); ?>>
 
-			<?php while ( have_posts() ) : the_post(); ?>
+			<?php
+			while ( have_posts() ) :
+				the_post();
+				?>
 
 				<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>itemscope itemtype="https://schema.org/ImageObject">
 					<?php get_template_part( 'template-parts/entry-header' ); ?>
@@ -24,13 +27,24 @@ get_header(); ?>
 								 * Grab the IDs of all the image attachments in a gallery so we can get the URL of the next adjacent image in a gallery,
 								 * or the first image (if we're looking at the last image in a gallery), or, in a gallery of one, just the link to that image file
 								 */
-								$attachments = array_values( get_children( array( 'post_parent' => $post->post_parent, 'post_status' => 'inherit', 'post_type' => 'attachment', 'post_mime_type' => 'image', 'order' => 'ASC', 'orderby' => 'menu_order ID' ) ) );
+								$attachments = array_values(
+									get_children(
+										array(
+											'post_parent' => $post->post_parent,
+											'post_status' => 'inherit',
+											'post_type' => 'attachment',
+											'post_mime_type' => 'image',
+											'order' => 'ASC',
+											'orderby' => 'menu_order ID',
+										)
+									)
+								);
 								foreach ( $attachments as $k => $attachment ) {
 									if ( $attachment->ID == $post->ID ) {
 										break;
 									}
 								}
-								$k++;
+								++$k;
 								// If there is more than 1 attachment in a gallery
 								if ( count( $attachments ) > 1 ) {
 									if ( isset( $attachments[ $k ] ) ) {
@@ -46,10 +60,12 @@ get_header(); ?>
 								}
 								?>
 
-								<a href="<?php echo $next_attachment_url; ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="attachment"><?php
-								$attachment_size = apply_filters( 'autonomie_attachment_size', 1200 );
-								echo wp_get_attachment_image( $post->ID, array( $attachment_size, $attachment_size ), null, array( 'itemprop' => 'image contentURL' ) ); // filterable image width with, essentially, no limit for image height.
-								?></a>
+								<a href="<?php echo $next_attachment_url; ?>" title="<?php echo esc_attr( get_the_title() ); ?>" rel="attachment">
+													<?php
+													$attachment_size = apply_filters( 'autonomie_attachment_size', 1200 );
+													echo wp_get_attachment_image( $post->ID, array( $attachment_size, $attachment_size ), null, array( 'itemprop' => 'image contentURL' ) ); // filterable image width with, essentially, no limit for image height.
+													?>
+								</a>
 
 								<?php if ( ! empty( $post->post_excerpt ) ) : ?>
 								<figcaption class="entry-caption">
@@ -60,7 +76,14 @@ get_header(); ?>
 						</div><!-- .entry-attachment -->
 
 						<?php the_content(); ?>
-						<?php wp_link_pages( array( 'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ), 'after' => '</div>' ) ); ?>
+						<?php
+						wp_link_pages(
+							array(
+								'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ),
+								'after' => '</div>',
+							)
+						);
+						?>
 					</div><!-- .entry-content -->
 
 					<?php get_template_part( 'template-parts/entry-footer' ); ?>

--- a/image.php
+++ b/image.php
@@ -72,4 +72,5 @@ get_header(); ?>
 
 			</main><!-- #content -->
 
-<?php get_footer(); ?>
+<?php
+get_footer();

--- a/includes/compat.php
+++ b/includes/compat.php
@@ -64,9 +64,11 @@ function autonomie_query_format_standard( $query ) {
 			}
 			$query->is_tax = null;
 
-			unset( $query->query_vars['post_format'] );
-			unset( $query->query_vars['taxonomy'] );
-			unset( $query->query_vars['term'] );
+			unset(
+				$query->query_vars['post_format'],
+				$query->query_vars['taxonomy'],
+				$query->query_vars['term']
+			);
 
 			$query->set(
 				'tax_query',

--- a/includes/compat.php
+++ b/includes/compat.php
@@ -19,8 +19,8 @@
 /**
  * Adds the new  input types to the comment-form
  *
- * @param string $form
- * @return string
+ * @param array $fields The comment form fields.
+ * @return array
  */
 function autonomie_comment_autocomplete( $fields ) {
 	$fields['author'] = preg_replace( '/<input/', '<input autocomplete="nickname name" enterkeyhint="next" ', $fields['author'] );
@@ -105,7 +105,7 @@ add_filter( 'the_content', 'autonomie_add_lazy_loading', 99 );
 
 add_filter(
 	'wp_lazy_loading_enabled',
-	function( $default, $tag_name, $context ) {
+	function ( $default, $tag_name, $context ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound
 		if ( 'the_content' === $context ) {
 			return false;
 		}

--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -10,7 +10,7 @@ function autonomie_customize_register( $wp_customize ) {
 		'autonomie_settings_section',
 		array(
 			'title' => __( 'Advanced Settings', 'autonomie' ),
-			'description' => __( 'Enable/Disable some advanced Autonomie features.', 'autonomie' ), //Descriptive tooltip
+			'description' => __( 'Enable/Disable some advanced Autonomie features.', 'autonomie' ), //Descriptive tooltip.
 			'priority' => 35,
 		)
 	);

--- a/includes/featured-image.php
+++ b/includes/featured-image.php
@@ -150,7 +150,7 @@ add_action( 'save_post', 'autonomie_save_post', 5, 1 );
  * or none of the above conditions are true.
  */
 function autonomie_has_full_width_featured_image() {
-	// If this isn't a Single post type or we don't have a Featured Image set
+	// If this isn't a Single post type, or we don't have a Featured Image set.
 	if ( ! ( is_single() || is_page() ) || ! has_post_thumbnail() ) {
 		return false;
 	}

--- a/includes/featured-image.php
+++ b/includes/featured-image.php
@@ -157,7 +157,7 @@ function autonomie_has_full_width_featured_image() {
 
 	$full_width_featured_image = get_post_meta( get_the_ID(), 'full_width_featured_image', true );
 
-	// If Use featured image as Post Cover has been checked in the Featured Image meta box, return true.
+	// If "Use featured image as Post Cover" has been checked in the Featured Image meta box, return true.
 	if ( '1' === $full_width_featured_image ) {
 		return true;
 	}

--- a/includes/featured-image.php
+++ b/includes/featured-image.php
@@ -104,29 +104,31 @@ add_filter( 'admin_post_thumbnail_html', 'autonomie_featured_image_meta', 10, 2 
  * Safe the Post Covers
  *
  * @param int $post_id The ID of the post being saved.
+ *
+ * @return void
  */
 function autonomie_save_post( $post_id ) {
 	// if this is an autosave, our form has not been submitted, so we don't want to do anything.
 	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-		return $post_id;
+		return;
 	}
 
 	if ( ! array_key_exists( 'full_width_featured_image', $_POST ) ) {
-		return $post_id;
+		return;
 	}
 
 	if ( ! array_key_exists( 'post_type', $_POST ) ) {
-		return $post_id;
+		return;
 	}
 
 	// check the user's permissions.
 	if ( 'page' === $_POST['post_type'] ) {
 		if ( ! current_user_can( 'edit_page', $post_id ) ) {
-			return $post_id;
+			return;
 		}
 	} else {
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			return $post_id;
+			return;
 		}
 	}
 

--- a/includes/feed.php
+++ b/includes/feed.php
@@ -12,7 +12,7 @@
  *
  * @param string $post_format the post format slug
  *
- * @return void
+ * @return string|false
  */
 function autonomie_get_post_format_archive_feed_link( $post_format, $feed = '' ) {
 	$default_feed = get_default_feed();
@@ -138,7 +138,12 @@ function autonomie_extend_singular_feed_discovery( $args = array() ) {
 
 	foreach ( $feeds as $feed ) {
 		if ( array_key_exists( 'href', $feed ) && array_key_exists( 'title', $feed ) ) {
-			printf( '<link rel="alternate" type="%s" title="%s" href="%s" />', esc_attr( feed_content_type() ), esc_attr( $feed['title'] ), esc_url( $feed['href'] ) );
+			printf(
+				'<link rel="alternate" type="%s" title="%s" href="%s" />',
+				esc_attr( feed_content_type() ),
+				esc_attr( $feed['title'] ),
+				esc_url( $feed['href'] )
+			);
 			echo PHP_EOL;
 		}
 	}

--- a/includes/feed.php
+++ b/includes/feed.php
@@ -126,9 +126,9 @@ function autonomie_extend_singular_feed_discovery( $args = array() ) {
 	// Add "standard" post-format feed discovery
 	global $wp_query;
 	if (
-		is_archive() &&
 		isset( $wp_query->query['post_format'] ) &&
-		'post-format-standard' === $wp_query->query['post_format']
+		'post-format-standard' === $wp_query->query['post_format'] &&
+		is_archive()
 	) {
 		$feeds[] = array(
 			'title' => sprintf( $args['posttypetitle'], get_bloginfo( 'name' ), $args['separator'], get_post_format_string( 'standard' ) ),

--- a/includes/semantics.php
+++ b/includes/semantics.php
@@ -52,9 +52,9 @@ function autonomie_post_classes( $classes ) {
 
 	if ( ! is_singular() ) {
 		return autonomie_get_post_classes( $classes );
-	} else {
-		return $classes;
 	}
+
+	return $classes;
 }
 add_filter( 'post_class', 'autonomie_post_classes', 99 );
 
@@ -120,6 +120,7 @@ function autonomie_pre_get_avatar_data( $args, $id_or_email ) {
 		$username = get_the_author_meta( 'display_name', $id_or_email );
 
 		if ( $username ) {
+			// translators: %s: username
 			$args['alt'] = sprintf( __( 'User Avatar of %s' ), $username );
 		} else {
 			$args['alt'] = __( 'User Avatar' );
@@ -133,7 +134,7 @@ add_filter( 'pre_get_avatar_data', 'autonomie_pre_get_avatar_data', 99, 2 );
 /**
  * Add rel-prev attribute to previous_image_link.
  *
- * @param string a-tag
+ * @param string $link The a-tag to filter.
  *
  * @return string
  */
@@ -145,7 +146,7 @@ add_filter( 'previous_image_link', 'autonomie_semantic_previous_image_link' );
 /**
  * Add rel-next attribute to next_image_link.
  *
- * @param string a-tag
+ * @param string $link The a-tag to filter.
  *
  * @return string
  */
@@ -157,7 +158,7 @@ add_filter( 'next_image_link', 'autonomie_semantic_next_image_link' );
 /**
  * Add rel-prev attribute to next_posts_link_attributes.
  *
- * @param string Attributes
+ * @param string $attr Attributes.
  *
  * @return string
  */
@@ -169,7 +170,7 @@ add_filter( 'next_posts_link_attributes', 'autonomie_next_posts_link_attributes'
 /**
  * Add rel-next attribute to previous_posts_link.
  *
- * @param string Attributes
+ * @param string $attr Attributes.
  *
  * @return string
  */
@@ -277,13 +278,13 @@ function autonomie_get_the_semantics( $id ) {
 	$classes = autonomie_get_semantics( $id );
 
 	if ( ! $classes ) {
-		return;
+		return '';
 	}
 
 	$class = '';
 
 	foreach ( $classes as $key => $value ) {
-		$class .= ' ' . esc_attr( $key ) . '="' . esc_attr( join( ' ', $value ) ) . '"';
+		$class .= ' ' . esc_attr( $key ) . '="' . esc_attr( implode( ' ', $value ) ) . '"';
 	}
 
 	return $class;
@@ -302,7 +303,7 @@ function autonomie_semantics( $id ) {
 	}
 
 	foreach ( $classes as $key => $value ) {
-		echo ' ' . esc_attr( $key ) . '="' . esc_attr( join( ' ', $value ) ) . '"';
+		echo ' ' . esc_attr( $key ) . '="' . esc_attr( implode( ' ', $value ) ) . '"';
 	}
 }
 
@@ -325,7 +326,7 @@ function autonomie_term_links_tag( $links ) {
 	}
 
 	if ( empty( $terms ) ) {
-		return false;
+		return array();
 	}
 
 	$links = array();

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -209,7 +209,7 @@ function autonomie_get_post_format_string() {
  *
  * @param string $post_format
  *
- * @return void
+ * @return string
  */
 function autonomie_get_post_format_link( $post_format ) {
 	if ( in_array( get_post_type(), array( 'page', 'attachment' ), true ) ) {

--- a/includes/webactions.php
+++ b/includes/webactions.php
@@ -2,12 +2,12 @@
 /**
  * Add Webactions to the reply links in the comment section.
  *
- * @param string $link the html representation of the comment link
- * @param array $args associative array of options
- * @param int $comment ID of comment being replied to
- * @param int $post ID of post that comment is going to be displayed on
+ * @param string     $link    The HTML markup for the comment reply link.
+ * @param array      $args    An array of arguments overriding the defaults.
+ * @param WP_Comment $comment The object of the comment being replied.
+ * @param WP_Post    $post    The WP_Post object.
  *
- * @return string the new reply link
+ * @return string The new reply link.
  */
 function autonomie_webaction_comment_reply_link( $link, $args, $comment, $post ) {
 	$permalink = get_permalink( $post->ID );

--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -3,10 +3,10 @@
  * Register widgetized area and update sidebar with default widgets.
  */
 function autonomie_widgets_init() {
-	require( get_template_directory() . '/widgets/class-autonomie-author-widget.php' );
+	require get_template_directory() . '/widgets/class-autonomie-author-widget.php';
 	register_widget( 'Autonomie_Author_Widget' );
 
-	require( get_template_directory() . '/widgets/class-autonomie-taxonomy-widget.php' );
+	require get_template_directory() . '/widgets/class-autonomie-taxonomy-widget.php';
 	register_widget( 'Autonomie_Taxonomy_Widget' );
 
 	register_sidebar(
@@ -83,7 +83,7 @@ function autonomie_starter_content_add_widget( $content, $config ) {
 }
 add_filter( 'get_theme_starter_content', 'autonomie_starter_content_add_widget', 10, 2 );
 
-function autonomie_activate () {
+function autonomie_activate() {
 	// Set up default widgets for default theme.
 	update_option(
 		'widget_autonomie-author',
@@ -126,4 +126,4 @@ function autonomie_activate () {
 	);
 }
 
-add_action('after_switch_theme', 'autonomie_activate');
+add_action( 'after_switch_theme', 'autonomie_activate' );

--- a/index.php
+++ b/index.php
@@ -19,7 +19,10 @@ get_header(); ?>
 		<?php if ( have_posts() ) : ?>
 
 			<?php /* Start the Loop */ ?>
-			<?php while ( have_posts() ) : the_post(); ?>
+			<?php
+			while ( have_posts() ) :
+				the_post();
+				?>
 
 				<?php
 					/* Include the Post-Format-specific template for the content.

--- a/index.php
+++ b/index.php
@@ -50,4 +50,5 @@ get_header(); ?>
 
 		<?php autonomie_content_nav( 'nav-below' ); ?>
 
-<?php get_footer(); ?>
+<?php
+get_footer();

--- a/integrations/activitypub.php
+++ b/integrations/activitypub.php
@@ -21,7 +21,7 @@
 function autonomie_activitypub_archive_author_meta( $meta, $author_id ) {
 	$meta[] = sprintf(
 		// translators:
-		__( '<indie-action do="follow" width="%1$s">Follow <code>%2$s</code> (fediverse)</indie-action>', 'autonomie' ),
+		__( '<indie-action do="follow" with="%1$s">Follow <code>%2$s</code> (fediverse)</indie-action>', 'autonomie' ),
 		get_author_posts_url( $author_id ),
 		\Activitypub\get_webfinger_resource( $author_id )
 	);

--- a/integrations/activitypub.php
+++ b/integrations/activitypub.php
@@ -11,7 +11,7 @@
  */
 
 /**
- * Add ActivityPub informations to the archive author meta data
+ * Add ActivityPub information to the archive author metadata.
  *
  * @param  array $meta      the meta array
  * @param  int   $author_id the author id
@@ -19,8 +19,12 @@
  * @return array            the filtered meta array
  */
 function autonomie_activitypub_archive_author_meta( $meta, $author_id ) {
-	// translators: how to follow
-	$meta[] = sprintf( __( '<indie-action do="follow" width="%1$s">Follow <code>%2$s</code> (fediverse)</indie-action>', 'autonomie' ), get_author_posts_url( $author_id ), \Activitypub\get_webfinger_resource( $author_id ) );
+	$meta[] = sprintf(
+		// translators:
+		__( '<indie-action do="follow" width="%1$s">Follow <code>%2$s</code> (fediverse)</indie-action>', 'autonomie' ),
+		get_author_posts_url( $author_id ),
+		\Activitypub\get_webfinger_resource( $author_id )
+	);
 
 	return $meta;
 }
@@ -29,10 +33,10 @@ add_filter( 'autonomie_archive_author_meta', 'autonomie_activitypub_archive_auth
 /**
  * ActivityPub follower counter
  *
- * @param  int $followers the follower counter
- * @param  int $author_id the author id
+ * @param  int $followers The follower counter.
+ * @param  int $author_id The author id.
  *
- * @return array          the filtered counter
+ * @return int            The filtered counter.
  */
 function autonomie_activitypub_followers( $followers, $author_id ) {
 	$activitypub_followers = get_user_option( 'activitypub_followers', $author_id );

--- a/integrations/post-kinds.php
+++ b/integrations/post-kinds.php
@@ -11,7 +11,7 @@
  */
 
 /**
- * Removes native Post-Kinds implementation
+ * Removes native Post-Kinds implementation.
  */
 function autonomie_post_kinds_init() {
 	if ( method_exists( 'Kind_Taxonomy', 'get_icon' ) ) {
@@ -25,9 +25,7 @@ function autonomie_post_kinds_init() {
 add_action( 'init', 'autonomie_post_kinds_init' );
 
 /**
- * Adds the reply-context above the article body
- *
- * @return string the reply-context
+ * Adds the reply-context above the article body.
  */
 function autonomie_post_kinds_content() {
 	printf( '<div class="entry-reaction">%s</div>', Kind_View::get_display() );
@@ -35,10 +33,10 @@ function autonomie_post_kinds_content() {
 add_action( 'autonomie_before_entry_content', 'autonomie_post_kinds_content' );
 
 /**
- * Replace the Post-Format header with the Post-Kinds header
+ * Replace the Post-Format header with the Post-Kinds header.
  *
- * @param  string $post_format_html Post-Format html
- * @return string                   Post-Kind html
+ * @param  string $post_format_html Post-Format html.
+ * @return string                   Post-Kind html.
  */
 function autonomie_post_kinds_format( $post_format_html ) {
 	if ( ! get_post_kind_slug() ) {

--- a/integrations/syndication-links.php
+++ b/integrations/syndication-links.php
@@ -14,7 +14,7 @@
  * Remove the integration of `the_content` filter
  */
 function autonomie_syndication_links_init() {
-	remove_filter( 'the_content', array( 'Syn_Config', 'the_content' ) , 30 );
+	remove_filter( 'the_content', array( 'Syn_Config', 'the_content' ), 30 );
 }
 add_action( 'init', 'autonomie_syndication_links_init' );
 
@@ -33,7 +33,7 @@ function autonomie_syndication_links() {
 	if ( function_exists( 'get_syndication_links' ) ) {
 		echo '<div class="syndication-links">';
 		_e( 'Syndication Links', 'autonomie' );
-		echo get_syndication_links( null, array( 'show_text_before' => null) );
+		echo get_syndication_links( null, array( 'show_text_before' => null ) );
 		echo '</div>';
 	}
 }

--- a/offline.php
+++ b/offline.php
@@ -22,4 +22,5 @@ get_header(); ?>
 
 		</main><!-- #content -->
 
-<?php get_footer(); ?>
+<?php
+get_footer();

--- a/page-now.php
+++ b/page-now.php
@@ -29,4 +29,5 @@ get_header(); ?>
 
 		</main><!-- #content -->
 
-<?php get_footer(); ?>
+<?php
+get_footer();

--- a/page-now.php
+++ b/page-now.php
@@ -19,7 +19,10 @@ get_header(); ?>
 
 		<main id="primary" <?php autonomie_main_class( 'h-now' ); ?><?php autonomie_semantics( 'main' ); ?>>
 
-			<?php while ( have_posts() ) : the_post(); ?>
+			<?php
+			while ( have_posts() ) :
+				the_post();
+				?>
 
 				<?php get_template_part( 'templates/content', 'page' ); ?>
 

--- a/page.php
+++ b/page.php
@@ -25,4 +25,5 @@ get_header(); ?>
 
 		</main><!-- #content -->
 
-<?php get_footer(); ?>
+<?php
+get_footer();

--- a/page.php
+++ b/page.php
@@ -15,7 +15,10 @@ get_header(); ?>
 
 		<main id="primary" <?php autonomie_main_class(); ?><?php autonomie_semantics( 'main' ); ?>>
 
-			<?php while ( have_posts() ) : the_post(); ?>
+			<?php
+			while ( have_posts() ) :
+				the_post();
+				?>
 
 				<?php get_template_part( 'templates/content', 'page' ); ?>
 

--- a/readme.md
+++ b/readme.md
@@ -2,9 +2,9 @@
 **Contributors:** [pfefferle](https://profiles.wordpress.org/pfefferle/)  
 **Tags:** custom-menu, custom-colors, custom-header, custom-logo, featured-image-header, flexible-header, sticky-post, microformats, rtl-language-support, translation-ready, full-width-template, post-formats, threaded-comments, footer-widgets, one-column, editor-style, featured-images, theme-options, blog, news, photography, entertainment, wide-blocks  
 **Requires at least:** 4.0  
-**Tested up to:** 5.5  
+**Tested up to:** 6.8  
 **Stable tag:** 1.0.0  
-**Requires PHP:** 5.6  
+**Requires PHP:** 7.4  
 **Author:** Matthias Pfefferle  
 **Author URI:** https://notiz.blog/  
 **Donate link:** https://notiz.blog/donate/  

--- a/single.php
+++ b/single.php
@@ -10,7 +10,10 @@ get_header(); ?>
 
 			<main id="primary" <?php autonomie_main_class(); ?><?php autonomie_semantics( 'main' ); ?>>
 
-			<?php while ( have_posts() ) : the_post(); ?>
+			<?php
+			while ( have_posts() ) :
+				the_post();
+				?>
 
 				<?php get_template_part( 'templates/content', get_post_format() ); ?>
 

--- a/single.php
+++ b/single.php
@@ -27,4 +27,5 @@ get_header(); ?>
 
 			<?php autonomie_content_nav( 'nav-below' ); ?>
 
-<?php get_footer(); ?>
+<?php
+get_footer();

--- a/template-parts/entry-footer.php
+++ b/template-parts/entry-footer.php
@@ -2,7 +2,7 @@
 	<footer class="entry-footer entry-meta">
 		<div class="entry-actions">
 			<?php if ( comments_open() || ( '0' !== get_comments_number() && ! comments_open() ) ) : ?>
-			<indie-action do="reply" width="<?php the_permalink(); ?>"><div class="comments-link"><?php comments_popup_link( __( 'Leave a comment', 'autonomie' ), __( '1 Comment', 'autonomie' ), __( '% Comments', 'autonomie' ) ); ?></div></indie-action>
+			<indie-action do="reply" with="<?php the_permalink(); ?>"><div class="comments-link"><?php comments_popup_link( __( 'Leave a comment', 'autonomie' ), __( '1 Comment', 'autonomie' ), __( '% Comments', 'autonomie' ) ); ?></div></indie-action>
 			<?php endif; ?>
 			<?php get_template_part( 'template-parts/entry', 'share' ); ?>
 		</div>
@@ -16,7 +16,7 @@
 	<footer class="entry-footer entry-meta">
 		<?php if ( comments_open() || ( '0' !== get_comments_number() && ! comments_open() ) ) : ?>
 		<div class="entry-actions">
-			<indie-action do="reply" width="<?php the_permalink(); ?>"><div class="comments-link"><?php comments_popup_link( __( 'Leave a comment', 'autonomie' ), __( '1 Comment', 'autonomie' ), __( '% Comments', 'autonomie' ) ); ?></div></indie-action>
+			<indie-action do="reply" with="<?php the_permalink(); ?>"><div class="comments-link"><?php comments_popup_link( __( 'Leave a comment', 'autonomie' ), __( '1 Comment', 'autonomie' ), __( '% Comments', 'autonomie' ) ); ?></div></indie-action>
 		<div>
 		<?php endif; ?>
 	</footer><!-- #entry-meta -->

--- a/template-parts/entry-header.php
+++ b/template-parts/entry-header.php
@@ -1,13 +1,18 @@
 	<header class="entry-header">
 		<div class="entry-header-wrapper">
 			<div class="entry-meta post-format">
-				<?php echo apply_filters( 'autonomie_post_format', sprintf(
-					'<a class="entry-format entry-format-%s entry-type-%s" href="%s">%s</a>',
-					autonomie_get_post_format(),
-					get_post_type(),
-					esc_url( autonomie_get_post_format_link( autonomie_get_post_format() ) ),
-					autonomie_get_post_format_string()
-				) ); ?>
+				<?php
+				echo apply_filters(
+					'autonomie_post_format',
+					sprintf(
+						'<a class="entry-format entry-format-%s entry-type-%s" href="%s">%s</a>',
+						autonomie_get_post_format(),
+						get_post_type(),
+						esc_url( autonomie_get_post_format_link( autonomie_get_post_format() ) ),
+						autonomie_get_post_format_string()
+					)
+				);
+				?>
 			</div>
 
 			<?php
@@ -17,7 +22,7 @@
 				} else {
 					$title_element = 'h2';
 				}
-			?>
+				?>
 			<<?php echo $title_element; ?> class="entry-title p-name" itemprop="name headline">
 				<a href="<?php the_permalink(); ?>" class="u-url url" title="<?php printf( esc_attr__( 'Permalink to %s', 'autonomie' ), the_title_attribute( 'echo=0' ) ); ?>" rel="bookmark" itemprop="url">
 					<?php the_title(); ?>

--- a/template-parts/entry-nav.php
+++ b/template-parts/entry-nav.php
@@ -10,35 +10,35 @@
 		foreach ( $prev_post as $post ) {
 			setup_postdata( $post );
 			?>
-		<div class="previous-post" style="background-image: url( <?php the_post_thumbnail_url( $post->ID, "medium" ); ?>">
+		<div class="previous-post" style="background-image: url( <?php the_post_thumbnail_url( $post->ID, 'medium' ); ?>">
 			<a class="previous" href="<?php the_permalink(); ?>">&laquo; Previous Story</a>
 			<h4><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h4>
 			<small><?php the_date( 'F j, Y' ); ?></small>
 		</div>
 			<?php
 				wp_reset_postdata();
-			} //end foreach
-		} // end if
+		} //end foreach
+	} // end if
 
-		$next_post = get_next_post( true );
+	$next_post = get_next_post( true );
 
-		if ( $next_post ) {
-			$args = array(
-				'posts_per_page' => 1,
-				'include' => $next_post->ID,
-			);
-			$next_post = get_posts( $args );
-			foreach ( $next_post as $post ) {
-				setup_postdata( $post );
-				?>
+	if ( $next_post ) {
+		$args = array(
+			'posts_per_page' => 1,
+			'include' => $next_post->ID,
+		);
+		$next_post = get_posts( $args );
+		foreach ( $next_post as $post ) {
+			setup_postdata( $post );
+			?>
 		<div class="next-post" style="background-image: url( <?php the_post_thumbnail_url( $post->ID, 'medium' ); ?>">
 			<a class="next" href="<?php the_permalink(); ?>">Next Story &raquo;</a>
 			<h4><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h4>
 			<small><?php the_date( 'F j, Y' ); ?></small>
 		</div>
 			<?php
-				wp_reset_postdata();
-			} //end foreach
-		} // end if
+			wp_reset_postdata();
+		} //end foreach
+	} // end if
 	?>
 </div>

--- a/template-parts/entry-share.php
+++ b/template-parts/entry-share.php
@@ -15,17 +15,17 @@
 		<input id="entry-permalink" class="u-url url u-uid uid bookmark" type="text" value="<?php echo get_permalink(); ?>" />
 	</p>
 	<?php
-	// some comment ;)
+	// Some comment ;)
 	if ( get_the_title() ) {
 		?>
 	<p>
 		<label for="entry-summary"><?php _e( 'HTML', 'autonomie' ); ?></label>
-		<textarea id="entry-summary" class="code" type="text" rows="5" cols="70">&lt;cite class=&quot;h-cite&quot;&gt;&lt;a class=&quot;u-url p-name&quot; href=&quot;<?php echo get_permalink(); ?>&quot;&gt;<?php echo get_the_title(); ?>&lt;/a&gt; (&lt;span class=&quot;p-author h-card&quot; title=&quot;<?php echo get_the_author(); ?>&quot;&gt;<?php echo get_the_author(); ?>&lt;/span&gt; &lt;time class=&quot;dt-published&quot; datetime=&quot;<?php echo get_the_date( 'c' ); ?>&quot;&gt;<?php echo get_the_date(); ?>&lt;/time&gt;)&lt;/cite&gt;</textarea>
+		<textarea id="entry-summary" class="code" rows="5" cols="70">&lt;cite class=&quot;h-cite&quot;&gt;&lt;a class=&quot;u-url p-name&quot; href=&quot;<?php echo get_permalink(); ?>&quot;&gt;<?php echo get_the_title(); ?>&lt;/a&gt; (&lt;span class=&quot;p-author h-card&quot; title=&quot;<?php echo get_the_author(); ?>&quot;&gt;<?php echo get_the_author(); ?>&lt;/span&gt; &lt;time class=&quot;dt-published&quot; datetime=&quot;<?php echo get_the_date( 'c' ); ?>&quot;&gt;<?php echo get_the_date(); ?>&lt;/time&gt;)&lt;/cite&gt;</textarea>
 	</p>
 	<?php } else { ?>
 	<p>
 		<label for="entry-blockquote"><?php _e( 'HTML', 'autonomie' ); ?></label>
-		<textarea id="entry-blockquote" class="code" type="text" rows="5" cols="70">&lt;blockquote&gt;&lt;p&gt;<?php echo get_the_excerpt(); ?>&lt;/p&gt;&lt;small&gt;—&nbsp;by &lt;a href=&quot;<?php echo get_permalink(); ?>&quot; class=&quot;h-card&quot; title=&quot;<?php echo get_the_author(); ?>&quot;&gt;<?php echo get_the_author(); ?>&lt;/a&gt;&lt;/small&gt;&lt;/blockquote&gt;</textarea>
+		<textarea id="entry-blockquote" class="code" rows="5" cols="70">&lt;blockquote&gt;&lt;p&gt;<?php echo get_the_excerpt(); ?>&lt;/p&gt;&lt;small&gt;—&nbsp;by &lt;a href=&quot;<?php echo get_permalink(); ?>&quot; class=&quot;h-card&quot; title=&quot;<?php echo get_the_author(); ?>&quot;&gt;<?php echo get_the_author(); ?>&lt;/a&gt;&lt;/small&gt;&lt;/blockquote&gt;</textarea>
 	</p>
 	<?php } ?>
 </div>

--- a/template-parts/entry-share.php
+++ b/template-parts/entry-share.php
@@ -1,4 +1,4 @@
-<indie-action do="post" with="<?php echo get_permalink(); ?>">
+<indie-action do="post" with="<?php echo esc_url( get_permalink() ); ?>">
 	<button type="share" id="entry-share">
 		<?php _e( 'share', 'autonomie' ); ?>
 	</button>
@@ -8,11 +8,11 @@
 	<p><strong>Sharing is caring ❤️</strong></p>
 	<p>
 		<label for="entry-shortlink"><?php _e( 'Shortlink', 'autonomie' ); ?></label>
-		<input id="entry-shortlink" class="u-url url shortlink" type="text" value="<?php echo wp_get_shortlink(); ?>" />
+		<input id="entry-shortlink" class="u-url url shortlink" type="text" value="<?php echo esc_url( wp_get_shortlink() ); ?>" />
 	</p>
 	<p>
 		<label for="entry-permalink"><?php _e( 'Permalink', 'autonomie' ); ?></label>
-		<input id="entry-permalink" class="u-url url u-uid uid bookmark" type="text" value="<?php echo get_permalink(); ?>" />
+		<input id="entry-permalink" class="u-url url u-uid uid bookmark" type="text" value="<?php echo esc_url( get_permalink() ); ?>" />
 	</p>
 	<?php
 	// Some comment ;)
@@ -20,12 +20,12 @@
 		?>
 	<p>
 		<label for="entry-summary"><?php _e( 'HTML', 'autonomie' ); ?></label>
-		<textarea id="entry-summary" class="code" rows="5" cols="70">&lt;cite class=&quot;h-cite&quot;&gt;&lt;a class=&quot;u-url p-name&quot; href=&quot;<?php echo get_permalink(); ?>&quot;&gt;<?php echo get_the_title(); ?>&lt;/a&gt; (&lt;span class=&quot;p-author h-card&quot; title=&quot;<?php echo get_the_author(); ?>&quot;&gt;<?php echo get_the_author(); ?>&lt;/span&gt; &lt;time class=&quot;dt-published&quot; datetime=&quot;<?php echo get_the_date( 'c' ); ?>&quot;&gt;<?php echo get_the_date(); ?>&lt;/time&gt;)&lt;/cite&gt;</textarea>
+		<textarea id="entry-summary" class="code" rows="5" cols="70">&lt;cite class=&quot;h-cite&quot;&gt;&lt;a class=&quot;u-url p-name&quot; href=&quot;<?php echo esc_url( get_permalink() ); ?>&quot;&gt;<?php echo esc_html( get_the_title() ); ?>&lt;/a&gt; (&lt;span class=&quot;p-author h-card&quot; title=&quot;<?php echo esc_attr( get_the_author() ); ?>&quot;&gt;<?php echo esc_html( get_the_author() ); ?>&lt;/span&gt; &lt;time class=&quot;dt-published&quot; datetime=&quot;<?php echo esc_attr( get_the_date( 'c' ) ); ?>&quot;&gt;<?php echo esc_html( get_the_date() ); ?>&lt;/time&gt;)&lt;/cite&gt;</textarea>
 	</p>
 	<?php } else { ?>
 	<p>
 		<label for="entry-blockquote"><?php _e( 'HTML', 'autonomie' ); ?></label>
-		<textarea id="entry-blockquote" class="code" rows="5" cols="70">&lt;blockquote&gt;&lt;p&gt;<?php echo get_the_excerpt(); ?>&lt;/p&gt;&lt;small&gt;—&nbsp;by &lt;a href=&quot;<?php echo get_permalink(); ?>&quot; class=&quot;h-card&quot; title=&quot;<?php echo get_the_author(); ?>&quot;&gt;<?php echo get_the_author(); ?>&lt;/a&gt;&lt;/small&gt;&lt;/blockquote&gt;</textarea>
+		<textarea id="entry-blockquote" class="code" rows="5" cols="70">&lt;blockquote&gt;&lt;p&gt;<?php echo esc_html( get_the_excerpt() ); ?>&lt;/p&gt;&lt;small&gt;—&nbsp;by &lt;a href=&quot;<?php echo esc_url( get_permalink() ); ?>&quot; class=&quot;h-card&quot; title=&quot;<?php echo esc_attr( get_the_author() ); ?>&quot;&gt;<?php echo esc_html( get_the_author() ); ?>&lt;/a&gt;&lt;/small&gt;&lt;/blockquote&gt;</textarea>
 	</p>
 	<?php } ?>
 </div>

--- a/template-parts/entry-taxonomy.php
+++ b/template-parts/entry-taxonomy.php
@@ -2,10 +2,13 @@
 /* translators: used between list items, there is a space after the comma */
 $categories_list = get_the_category_list();
 if ( $categories_list ) :
-?>
+	?>
 <div class="cat-links">
 	<?php echo __( 'Categories', 'autonomie' ); ?>
-	<?php printf( __( '%1$s', 'autonomie' ), $categories_list ); ?>
+	<?php
+	// translators: %1$s Category list in HTML.
+	printf( __( '%1$s', 'autonomie' ), $categories_list );
+	?>
 </div>
 <?php endif; // End if categories ?>
 
@@ -13,9 +16,12 @@ if ( $categories_list ) :
 /* translators: used between list items, there is a space after the comma */
 $tags_list = get_the_tag_list( '<ul><li>', '</li><li>', '</li></ul>' );
 if ( $tags_list ) :
-?>
+	?>
 <div class="tag-links" itemprop="keywords">
 	<?php echo __( 'Tags', 'autonomie' ); ?>
-	<?php printf( __( '%1$s', 'autonomie' ), $tags_list ); ?>
+	<?php
+	// translators: %1$s Tag list in HTML.
+	printf( __( '%1$s', 'autonomie' ), $tags_list );
+	?>
 </div>
 <?php endif; // End if $tags_list ?>

--- a/template-parts/page-banner.php
+++ b/template-parts/page-banner.php
@@ -9,7 +9,7 @@
 		<div id="page-description"<?php autonomie_semantics( 'page-description' ); ?>><?php echo autonomie_get_the_archive_description(); ?></div>
 		<?php } ?>
 	</div>
-	<?php printf( '<link itemprop="mainEntityOfPage" href="%s" />', get_self_link() ); ?>
+		<?php printf( '<link itemprop="mainEntityOfPage" href="%s" />', get_self_link() ); ?>
 	<?php endif; ?>
 </div>
 <?php endif; ?>

--- a/templates/content-aside.php
+++ b/templates/content-aside.php
@@ -15,7 +15,14 @@
 	<?php autonomie_the_post_thumbnail( '<div class="entry-media">', '</div>' ); ?>
 	<div class="entry-content e-content p-summary entry-title p-name" itemprop="name headline description articleBody">
 		<?php autonomie_the_content(); ?>
-		<?php wp_link_pages( array( 'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ), 'after' => '</div>' ) ); ?>
+		<?php
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ),
+				'after' => '</div>',
+			)
+		);
+		?>
 	</div><!-- .entry-content -->
 
 	<?php get_template_part( 'template-parts/entry-footer' ); ?>

--- a/templates/content-audio.php
+++ b/templates/content-audio.php
@@ -15,7 +15,14 @@
 	<?php autonomie_the_post_thumbnail( '<div class="entry-media">', '</div>' ); ?>
 	<div class="entry-content e-content" itemprop="description articleBody">
 		<?php autonomie_the_content(); ?>
-		<?php wp_link_pages( array( 'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ), 'after' => '</div>' ) ); ?>
+		<?php
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ),
+				'after' => '</div>',
+			)
+		);
+		?>
 	</div><!-- .entry-content -->
 
 	<?php get_template_part( 'template-parts/entry-footer' ); ?>

--- a/templates/content-chat.php
+++ b/templates/content-chat.php
@@ -15,7 +15,14 @@
 	<?php autonomie_the_post_thumbnail( '<div class="entry-media">', '</div>' ); ?>
 	<div class="entry-content e-content" itemprop="articleBody description">
 		<?php autonomie_the_content(); ?>
-		<?php wp_link_pages( array( 'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ), 'after' => '</div>' ) ); ?>
+		<?php
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ),
+				'after' => '</div>',
+			)
+		);
+		?>
 	</div><!-- .entry-content -->
 
 	<?php get_template_part( 'template-parts/entry-footer' ); ?>

--- a/templates/content-gallery.php
+++ b/templates/content-gallery.php
@@ -15,7 +15,16 @@
 	<?php autonomie_the_post_thumbnail( '<div class="entry-media">', '</div>' ); ?>
 	<div class="entry-content e-content" itemprop="description">
 		<?php autonomie_the_content(); ?>
-		<?php wp_link_pages( array( 'before' => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'autonomie' ) . '</span>', 'after' => '</div>', 'link_before' => '<span>', 'link_after' => '</span>' ) ); ?>
+		<?php
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'autonomie' ) . '</span>',
+				'after' => '</div>',
+				'link_before' => '<span>',
+				'link_after' => '</span>',
+			)
+		);
+		?>
 	</div><!-- .entry-content -->
 
 	<?php get_template_part( 'template-parts/entry-footer' ); ?>

--- a/templates/content-image.php
+++ b/templates/content-image.php
@@ -15,7 +15,14 @@
 	<?php autonomie_the_post_thumbnail( '<div class="entry-media">', '</div>' ); ?>
 	<div class="entry-content e-content" itemprop="description articleBody">
 		<?php autonomie_the_content(); ?>
-		<?php wp_link_pages( array( 'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ), 'after' => '</div>' ) ); ?>
+		<?php
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ),
+				'after' => '</div>',
+			)
+		);
+		?>
 	</div><!-- .entry-content -->
 
 	<?php get_template_part( 'template-parts/entry-footer' ); ?>

--- a/templates/content-link.php
+++ b/templates/content-link.php
@@ -15,7 +15,14 @@
 	<?php autonomie_the_post_thumbnail( '<div class="entry-media">', '</div>' ); ?>
 	<div class="entry-content e-content p-summary entry-title p-name" itemprop="name headline description articleBody">
 		<?php autonomie_the_content(); ?>
-		<?php wp_link_pages( array( 'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ), 'after' => '</div>' ) ); ?>
+		<?php
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ),
+				'after' => '</div>',
+			)
+		);
+		?>
 	</div><!-- .entry-content -->
 
 	<?php get_template_part( 'template-parts/entry-footer' ); ?>

--- a/templates/content-page.php
+++ b/templates/content-page.php
@@ -15,7 +15,14 @@
 	<?php autonomie_the_post_thumbnail( '<div class="entry-media">', '</div>' ); ?>
 	<div class="entry-content e-content" itemprop="description text">
 		<?php autonomie_the_content(); ?>
-		<?php wp_link_pages( array( 'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ), 'after' => '</div>' ) ); ?>
+		<?php
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ),
+				'after' => '</div>',
+			)
+		);
+		?>
 	</div><!-- .entry-content -->
 
 	<?php get_template_part( 'template-parts/entry-footer' ); ?>

--- a/templates/content-quote.php
+++ b/templates/content-quote.php
@@ -15,7 +15,14 @@
 	<?php autonomie_the_post_thumbnail( '<div class="entry-media">', '</div>' ); ?>
 	<div class="entry-title p-name entry-content e-content" itemprop="name headline description articleBody">
 		<?php autonomie_the_content(); ?>
-		<?php wp_link_pages( array( 'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ), 'after' => '</div>' ) ); ?>
+		<?php
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ),
+				'after' => '</div>',
+			)
+		);
+		?>
 	</div><!-- .entry-content -->
 
 	<?php get_template_part( 'template-parts/entry-footer' ); ?>

--- a/templates/content-single.php
+++ b/templates/content-single.php
@@ -15,7 +15,14 @@
 	<?php autonomie_the_post_thumbnail( '<div class="entry-media">', '</div>' ); ?>
 	<div class="entry-content e-content" itemprop="description articleBody">
 		<?php autonomie_the_content(); ?>
-		<?php wp_link_pages( array( 'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ), 'after' => '</div>' ) ); ?>
+		<?php
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ),
+				'after' => '</div>',
+			)
+		);
+		?>
 	</div><!-- .entry-content -->
 
 	<?php get_template_part( 'template-parts/entry-footer' ); ?>

--- a/templates/content-status.php
+++ b/templates/content-status.php
@@ -15,7 +15,14 @@
 	<?php autonomie_the_post_thumbnail( '<div class="entry-media">', '</div>' ); ?>
 	<div class="entry-content e-content p-summary entry-title p-name" itemprop="name headline description articleBody">
 		<?php autonomie_the_content(); ?>
-		<?php wp_link_pages( array( 'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ), 'after' => '</div>' ) ); ?>
+		<?php
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ),
+				'after' => '</div>',
+			)
+		);
+		?>
 	</div><!-- .entry-content -->
 
 	<?php get_template_part( 'template-parts/entry-footer' ); ?>

--- a/templates/content-video.php
+++ b/templates/content-video.php
@@ -15,7 +15,14 @@
 	<?php autonomie_the_post_thumbnail( '<div class="entry-media">', '</div>' ); ?>
 	<div class="entry-content e-content" itemprop="description articleBody">
 		<?php autonomie_the_content(); ?>
-		<?php wp_link_pages( array( 'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ), 'after' => '</div>' ) ); ?>
+		<?php
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-link">' . __( 'Pages:', 'autonomie' ),
+				'after' => '</div>',
+			)
+		);
+		?>
 	</div><!-- .entry-content -->
 
 	<?php get_template_part( 'template-parts/entry-footer' ); ?>

--- a/templates/content.php
+++ b/templates/content.php
@@ -1,1 +1,2 @@
-<?php get_template_part( 'templates/content', 'single' );
+<?php
+get_template_part( 'templates/content', 'single' );


### PR DESCRIPTION
This PR includes Code Style, PHPdoc and other code quality fixes.

Pushes with just phpcbf are marked as such.

Besides a few marked places no output should be altered.

---

This recreates #71, which was closed when my fork left the fork network.
The branch and commits are identical to the original; follow-up commits in
this PR additionally address the still-valid Copilot review findings from
#71 (output escaping in `template-parts/entry-share.php` and the comment
`class` attribute in `functions.php`).

## Disclosure

Claude assisted with restoring the branch and with the follow-up escaping
commits. I reviewed the changes and take responsibility for them.
