### PR TITLE
fix: use wp_parse_url() in get_self_link()

### DIFF
--- a/includes/compat.php
+++ b/includes/compat.php
@@ -123,7 +123,7 @@ if ( ! function_exists( 'get_self_link' ) ) {
 	 * @return string Correct link for the atom:self element.
 	 */
 	function get_self_link() {
-		$host = @parse_url( home_url() );
+		$host = wp_parse_url( home_url() );
 		return set_url_scheme( 'http://' . $host['host'] . wp_unslash( $_SERVER['REQUEST_URI'] ) );
 	}
 }


### PR DESCRIPTION
`get_self_link()` in `includes/compat.php` used `@parse_url( home_url() )`.
phpcs flags two problems with that line:

- Silencing errors with `@` is discouraged; proper error handling should be used instead.
- `parse_url()` is discouraged because its output is inconsistent across PHP versions; `wp_parse_url()` should be used instead.

This switches to `wp_parse_url( home_url() )`, which drops the error-suppression
operator and uses the WordPress wrapper. The return value is still the parsed
array, so `$host['host']` continues to work unchanged.

Fixes #73

## Disclosure

Claude assisted with this change. I reviewed it and take responsibility for it.
