### PR TITLE
fix: replace deprecated get_webfinger_resource()

### DIFF
--- a/integrations/activitypub.php
+++ b/integrations/activitypub.php
@@ -20,7 +20,7 @@
  */
 function autonomie_activitypub_archive_author_meta( $meta, $author_id ) {
 	// translators: how to follow
-	$meta[] = sprintf( __( '<indie-action do="follow" width="%1$s">Follow <code>%2$s</code> (fediverse)</indie-action>', 'autonomie' ), get_author_posts_url( $author_id ), \Activitypub\get_webfinger_resource( $author_id ) );
+	$meta[] = sprintf( __( '<indie-action do="follow" width="%1$s">Follow <code>%2$s</code> (fediverse)</indie-action>', 'autonomie' ), get_author_posts_url( $author_id ), \Activitypub\Webfinger::get_user_resource( $author_id ) );
 
 	return $meta;
 }


### PR DESCRIPTION
`autonomie_activitypub_archive_author_meta()` in `integrations/activitypub.php`
called `\Activitypub\get_webfinger_resource()`, which is deprecated since the
ActivityPub plugin 7.1.0 and emits a `_deprecated_function()` notice.

This switches to its replacement, `\Activitypub\Webfinger::get_user_resource()`.
The deprecated function is itself just a thin wrapper around this method, so
the returned resource is unchanged and the call works across plugin versions
that predate the deprecation.

Fixes #74

## Disclosure

Claude assisted with this change. I reviewed it and take responsibility for it.
