### PR TITLE
fix: close entry-actions div in entry-footer

### DIFF
--- a/template-parts/entry-footer.php
+++ b/template-parts/entry-footer.php
@@ -17,7 +17,7 @@
 		<?php if ( comments_open() || ( '0' !== get_comments_number() && ! comments_open() ) ) : ?>
 		<div class="entry-actions">
 			<indie-action do="reply" width="<?php the_permalink(); ?>"><div class="comments-link"><?php comments_popup_link( __( 'Leave a comment', 'autonomie' ), __( '1 Comment', 'autonomie' ), __( '% Comments', 'autonomie' ) ); ?></div></indie-action>
-		<div>
+		</div>
 		<?php endif; ?>
 	</footer><!-- #entry-meta -->
 <?php endif; ?>


### PR DESCRIPTION
In the non-singular branch of `template-parts/entry-footer.php`, the
`<div class="entry-actions">` wrapper was closed with another opening
`<div>` instead of `</div>`, leaving the markup unbalanced (one stray
opening tag and a missing closing tag).

This replaces the stray `<div>` with `</div>`.

Fixes #75

## Disclosure

Claude assisted with this change. I reviewed it and take responsibility for it.
